### PR TITLE
css change for metrics-card

### DIFF
--- a/src/app/components/metrics-list/metrics-list.css
+++ b/src/app/components/metrics-list/metrics-list.css
@@ -7,7 +7,7 @@
 }
 
 .metrics-card{
-  max-width: 510px;
+  max-width: 480px;
   margin: 18px;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Metrics cards are now slightly narrower, with their maximum width reduced from 510px to 480px.
  - Users may notice a tighter layout, with minor adjustments to spacing and text wrapping within cards.
  - This change can subtly affect alignment in card grids at certain screen sizes.
  - No functional behavior changed; the update is purely visual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->