### PR TITLE
bug: 4453 -  I used a dialog-based toast instead of MatSnackBar 

### DIFF
--- a/src/app/components/share-modal/share-modal.css
+++ b/src/app/components/share-modal/share-modal.css
@@ -216,3 +216,10 @@ mat-icon {
         font-size: 13px;
       }
   }
+
+::ng-deep .toast-dialog .mat-mdc-dialog-container {
+  padding: 0;
+  box-shadow: none;
+  background: transparent;
+}
+

--- a/src/app/components/share-modal/share-modal.html
+++ b/src/app/components/share-modal/share-modal.html
@@ -44,3 +44,11 @@
     </div>
   </div>
 </div>
+
+<ng-template #dialogToast let-message>
+  <div class="mat-snackbar-clone">
+    <div class="mat-snackbar-label">
+      {{ message }}
+    </div>
+  </div>
+</ng-template>

--- a/src/app/components/share-modal/share-modal.ts
+++ b/src/app/components/share-modal/share-modal.ts
@@ -1,6 +1,6 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, TemplateRef, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { environment } from '../../../../environments/environment';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
@@ -14,14 +14,16 @@ type SharePlatform = 'linkedin' | 'whatsapp' | 'facebook' | 'instagram';
   styleUrl: './share-modal.css'
 })
 export class ShareModal {
-
+  @ViewChild('dialogToast', { static: true })
+  dialogToast!: TemplateRef<any>;
   shareLink = '';
   shareText = `This story really stayed with me, and I wanted to share it with you. Do take a moment to read it and help amplify these voices from the ground.`;
 
   constructor(
     private dialogRef: MatDialogRef<ShareModal>,
     @Inject(MAT_DIALOG_DATA) public data: any,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private dialog: MatDialog
   ) {
     this.shareLink =
       `${window.location.origin}/voices-from-the-ground?storyId=${this.data.storyId}`;
@@ -144,10 +146,32 @@ share(platform: SharePlatform) {
     horizontalPosition: 'left' | 'center' | 'right' = 'right',
     verticalPosition: 'top' | 'bottom' = 'top'
   ) {
-    this.snackBar.open(message, '', {
-      duration,
-      horizontalPosition,
-      verticalPosition,
+    if (!this.dialogToast) {
+      console.error('dialogToast template not found');
+      return;
+    }
+
+    const position: any = {};
+    position[verticalPosition] = '16px';
+
+    if (horizontalPosition === 'center') {
+      position.left = '50%';
+    } else {
+      position[horizontalPosition] = '16px';
+    }
+
+    // 🔹 Open a dialog on top of the existing dialog
+    const dialogRef1 = this.dialog.open(this.dialogToast, {
+      data: message,           // pass message directly
+      panelClass: 'toast-dialog',
+      hasBackdrop: false,      // no backdrop
+      disableClose: true,
+      position,
+      width: 'auto',
+      maxWidth: '90vw'
     });
+
+    // 🔹 Close this toast dialog only
+    setTimeout(() => dialogRef1.close(), duration);
   }
 }

--- a/src/app/components/share-modal/share-modal.ts
+++ b/src/app/components/share-modal/share-modal.ts
@@ -3,13 +3,12 @@ import { CommonModule } from '@angular/common';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { environment } from '../../../../environments/environment';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 type SharePlatform = 'linkedin' | 'whatsapp' | 'facebook' | 'instagram';
 
 @Component({
   selector: 'app-share-modal',
   standalone: true,
-  imports: [CommonModule, MatIconModule, MatSnackBarModule],
+  imports: [CommonModule, MatIconModule],
   templateUrl: './share-modal.html',
   styleUrl: './share-modal.css'
 })
@@ -22,7 +21,6 @@ export class ShareModal {
   constructor(
     private dialogRef: MatDialogRef<ShareModal>,
     @Inject(MAT_DIALOG_DATA) public data: any,
-    private snackBar: MatSnackBar,
     private dialog: MatDialog
   ) {
     this.shareLink =
@@ -161,7 +159,7 @@ share(platform: SharePlatform) {
     }
 
     // 🔹 Open a dialog on top of the existing dialog
-    const dialogRef1 = this.dialog.open(this.dialogToast, {
+    const dialogRef = this.dialog.open(this.dialogToast, {
       data: message,           // pass message directly
       panelClass: 'toast-dialog',
       hasBackdrop: false,      // no backdrop
@@ -172,6 +170,6 @@ share(platform: SharePlatform) {
     });
 
     // 🔹 Close this toast dialog only
-    setTimeout(() => dialogRef1.close(), duration);
+    setTimeout(() => dialogRef.close(), duration);
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -128,3 +128,46 @@ h1, h2, h3, h4, h5, h6 {
 .cdk-overlay-pane:has(.heatmap-tooltip) {
   margin-top: -50px;
 }
+
+
+.toast-dialog,
+.toast-dialog .mat-mdc-dialog-container,
+.toast-dialog .mdc-dialog__surface {
+  background: transparent !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  overflow: visible !important;
+}
+
+
+.mat-snackbar-clone {
+  background-color: #ffffff;
+  color: #2b2b2b;
+
+  /* EXACT border from your image */
+  border: 1px solid #ffffff;
+
+  box-shadow:
+  0px 3px 5px -1px rgba(0, 0, 0, 0.12),
+  0px 6px 10px 0px rgba(0, 0, 0, 0.12),
+  0px 1px 18px 0px rgba(0, 0, 0, 0.12);
+
+  min-height: 38px;
+  padding: 8px 16px;
+
+  display: inline-flex;
+  align-items: center;
+
+  font-size: 14px;
+  font-weight: 400;
+  font-family: Roboto, Arial, sans-serif;
+
+  white-space: nowrap;
+}
+
+/* Label text */
+.mat-snackbar-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 35px;
+}


### PR DESCRIPTION
because Material snackbars always render below dialogs, and the overlay/z-index approaches didn’t work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved feedback message notifications in the share modal with enhanced visual styling and positioning.

* **Style**
  * Refined toast notification appearance with better shadows, borders, spacing, and overall visual hierarchy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->